### PR TITLE
Fix for rebuilding of approved labs

### DIFF
--- a/ag/repo.go
+++ b/ag/repo.go
@@ -34,6 +34,11 @@ func (t Repository_Type) IsStudentRepo() bool {
 	return t == Repository_USER || t == Repository_GROUP
 }
 
+// IsGroupRepo returns true if the repository is a group repo type
+func (t Repository) IsGroupRepo() bool {
+	return t.RepoType == Repository_GROUP
+}
+
 // RepoType returns the repository type for the given path name.
 func RepoType(path string) (repoType Repository_Type) {
 	switch path {

--- a/public/src/components/forms/CourseForm.tsx
+++ b/public/src/components/forms/CourseForm.tsx
@@ -223,7 +223,6 @@ export class CourseForm<T> extends React.Component<ICourseFormProps, ICourseForm
     private async getOrgByName(orgName: string) {
         const accessLinkString = "https://github.com/organizations/" + orgName + "/settings/oauth_application_policy";
         const accessLink = <a href={accessLinkString}>here</a>;
-        console.log("Getting org by name: " + orgName);
         const result = await this.props.courseMan.getOrganization(orgName);
         const orgs: Organization[] = [];
         if (result instanceof Status) {

--- a/public/src/components/lab/LabResult.tsx
+++ b/public/src/components/lab/LabResult.tsx
@@ -26,7 +26,6 @@ export class LabResult extends React.Component<ILabResult, ILabResultState> {
     public render() {
         let labHeading: JSX.Element;
         if (this.props.authorName) {
-            console.log("Author name is " + this.props.authorName);
             labHeading = <h3>{this.props.authorName + ": "} {this.props.lab}</h3>;
         } else {
             labHeading = <div>
@@ -35,8 +34,6 @@ export class LabResult extends React.Component<ILabResult, ILabResultState> {
                 </p>
             </div>;
         }
-        console.log("Progress is " + this.props.progress
-         + " and status is " + this.setApprovedString() + " delivered on " + this.props.delivered);
         return (
             <Row>
                 <div className="col-lg-12">

--- a/public/src/pages/TeacherPage.tsx
+++ b/public/src/pages/TeacherPage.tsx
@@ -149,7 +149,6 @@ export class TeacherPage extends ViewPage {
                         `Warning! This action is irriversible!
                         Do you want to approve this lab?`,
                     )) {
-                        console.log("approving submission for course " + course.getCode());
                         await this.courseMan.approveSubmission(submissionID, course.getId());
                         this.navMan.refresh();
                     }

--- a/public/src/pages/views/LabResultView.tsx
+++ b/public/src/pages/views/LabResultView.tsx
@@ -17,7 +17,6 @@ export class LabResultView extends React.Component<ILabInfoProps> {
     public render() {
         if (this.props.labInfo.latest) {
             const latest = this.props.labInfo.latest;
-            console.log("Build log for " + this.props.authorName + " is " + latest.buildLog);
             const buildLog = latest.buildLog.split("\n").map((x) => <span>{x}<br /></span>);
             return (
                 <div className="col-md-9 col-sm-9 col-xs-12">

--- a/web/hooks.go
+++ b/web/hooks.go
@@ -56,15 +56,13 @@ func GithubHook(logger *zap.SugaredLogger, db database.Database, runner ci.Runne
 				refreshAssignmentsFromTestsRepo(logger, db, repo, uint64(p.Sender.ID))
 
 			case repo.IsStudentRepo():
-
-				// parse the lab name from the push payload
+				// parse the lab names from the push payload
 				modifiedLabs := p.HeadCommit.Modified
 				var labNames []string
 				for _, lab := range modifiedLabs {
 					labName := strings.Split(lab, "/")[0]
 					if !contains(labNames, labName) {
 						labNames = append(labNames, labName)
-						logger.Debug("Got lab name: ", labName)
 					}
 				}
 
@@ -77,7 +75,7 @@ func GithubHook(logger *zap.SugaredLogger, db database.Database, runner ci.Runne
 
 					// check whether the last submission to that assignment has already been approved
 					// if yes - ignore the tests for approved lab
-					lastSubmission, _ := db.GetSubmission(&pb.Submission{AssignmentID: assignment.GetID()})
+					lastSubmission, _ := db.GetSubmission(&pb.Submission{AssignmentID: assignment.GetID(), UserID: repo.GetUserID(), GroupID: repo.GetGroupID()})
 					if lastSubmission == nil || !lastSubmission.GetApproved() {
 						runTests(logger, db, runner, repo, p.Repository.CloneURL, p.HeadCommit.ID, scriptPath, assignment.GetID())
 					} else {

--- a/web/rebuild.go
+++ b/web/rebuild.go
@@ -31,8 +31,12 @@ func (s *AutograderService) rebuildSubmission(ctx context.Context, submissionID 
 	repo := repos[0]
 
 	s.logger.Info("Rebuilding user submission: repo url is: ", repo.GetHTMLURL())
+	// only rerun tests for unapproved submissions
+	if !submission.GetApproved() {
+		runTests(s.logger, s.db, s.runner, repo, repo.GetHTMLURL(), submission.GetCommitHash(), "ci/scripts", submission.GetAssignmentID())
 
-	runTests(s.logger, s.db, s.runner, repo, repo.GetHTMLURL(), submission.GetCommitHash(), "ci/scripts", submission.GetAssignmentID())
-
+	} else {
+		s.logger.Infof("Submission for this lab has already been approved")
+	}
 	return nil
 }

--- a/web/rebuild.go
+++ b/web/rebuild.go
@@ -31,12 +31,8 @@ func (s *AutograderService) rebuildSubmission(ctx context.Context, submissionID 
 	repo := repos[0]
 
 	s.logger.Info("Rebuilding user submission: repo url is: ", repo.GetHTMLURL())
-	// only rerun tests for unapproved submissions
-	if !submission.GetApproved() {
-		runTests(s.logger, s.db, s.runner, repo, repo.GetHTMLURL(), submission.GetCommitHash(), "ci/scripts", submission.GetAssignmentID())
 
-	} else {
-		s.logger.Infof("Submission for this lab has already been approved")
-	}
+	runTests(s.logger, s.db, s.runner, repo, repo.GetHTMLURL(), submission.GetCommitHash(), "ci/scripts", submission.GetAssignmentID())
+
 	return nil
 }


### PR DESCRIPTION
Previously approved labs would be marked as unapproved if rebuild of that lab was triggered by push event. Both push event and rebuild button event will now ignore already approved labs.