### PR TITLE
Link to the group creation page from the teacher page

### DIFF
--- a/public/src/pages/StudentPage.tsx
+++ b/public/src/pages/StudentPage.tsx
@@ -224,7 +224,7 @@ export class StudentPage extends ViewPage {
 
                 allLinks.push({ name: "Settings" });
                 allLinks.push({
-                    name: "Members", uri: this.pagePath + "/courses/" + courseID + "/members",
+                    name: "New Group", uri: this.pagePath + "/courses/" + courseID + "/members",
                 });
                 coursesLinks.push({
                     item: { name: course.course.getCode(), uri: this.pagePath + "/courses/" + courseID },


### PR DESCRIPTION
- the link leading to the group form (used to create a new group) has been renamed: was `Members`, now `New Group`
- the same link has been added to the teacher page links