### PR TITLE
Group updates

### DIFF
--- a/web/groups.go
+++ b/web/groups.go
@@ -105,24 +105,6 @@ func (s *AutograderService) updateGroup(ctx context.Context, sc scm.SCM, request
 		return err
 	}
 
-	if request.Status == pb.Group_REJECTED {
-		// if the group is rejected or deleted, it is enough to update its entry in the database.
-		if err := s.db.UpdateGroupStatus(request); err != nil {
-			return err
-		}
-		// if we delete a previously accepted group, reset the group's members enrollment status,
-		// so that they can later join other groups.
-		for _, member := range request.Users {
-			if err = s.db.UpdateGroupEnrollment(member.ID, course.ID); err != nil {
-				return err
-			}
-		}
-		return nil
-	}
-
-	// the group is being updated or approved;
-	// will create group repository and team and set group status to approved
-
 	// get users of group, check consistency of group request
 	users, err := s.getGroupUsers(request)
 	if err != nil {

--- a/web/groups_test.go
+++ b/web/groups_test.go
@@ -739,9 +739,8 @@ func TestDeleteApprovedGroup(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// reject the group
-	createdGroup.Status = pb.Group_REJECTED
-	if _, err = ags.UpdateGroup(ctx, createdGroup); err != nil {
+	// delete the group
+	if _, err = ags.DeleteGroup(ctx, &pb.GroupRequest{CourseID: course.ID, GroupID: createdGroup.ID}); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Previously, methods that use github API would sometimes fail due to context cancelling. That would result in group or student repository created correctly on the github, but no corresponding entries created in the database. Because of that, enrolling such user or approving such group would become impossible, as corresponding methods would fail, and github repositories had to be manually removed.

Now an already existing github repository will be correctly reflected in the database on the next attempt to enroll the student or approve the group.