### PR TITLE
Methods rename

### DIFF
--- a/database/database.go
+++ b/database/database.go
@@ -82,9 +82,9 @@ type Database interface {
 	// CreateRepository creates a new repository.
 	CreateRepository(repo *pb.Repository) error
 	// GetRepository returns the repository for the SCM provider's repository ID.
-	GetRepository(uint64) (*pb.Repository, error)
+	GetRepositoryByRemoteID(uint64) (*pb.Repository, error)
 	// GetRepositories returns repositories that match the given query.
 	GetRepositories(query *pb.Repository) ([]*pb.Repository, error)
 	// DeleteRepository deletes repository by the given ID
-	DeleteRepository(uint64) error
+	DeleteRepositoryByRemoteID(uint64) error
 }

--- a/database/gormdb.go
+++ b/database/gormdb.go
@@ -693,8 +693,8 @@ func (db *GormDB) CreateRepository(repo *pb.Repository) error {
 	return db.conn.Create(repo).Error
 }
 
-// GetRepository fetches repository by github ID.
-func (db *GormDB) GetRepository(rid uint64) (*pb.Repository, error) {
+// GetRepositoryByRemoteID fetches repository by github ID.
+func (db *GormDB) GetRepositoryByRemoteID(rid uint64) (*pb.Repository, error) {
 	// This uses the repository ID from the provider to search with,
 	// and not the id of the entry in the database
 	var repo pb.Repository
@@ -713,9 +713,9 @@ func (db *GormDB) GetRepositories(query *pb.Repository) ([]*pb.Repository, error
 	return repos, nil
 }
 
-// DeleteRepository deletes repository by ID
-func (db *GormDB) DeleteRepository(rid uint64) error {
-	repo, err := db.GetRepository(rid)
+// DeleteRepositoryByRemoteID deletes repository by github ID
+func (db *GormDB) DeleteRepositoryByRemoteID(rid uint64) error {
+	repo, err := db.GetRepositoryByRemoteID(rid)
 	if err != nil {
 		return err
 	}

--- a/database/gormdb_test.go
+++ b/database/gormdb_test.go
@@ -1164,7 +1164,7 @@ func TestGormDBGetInsertSubmissions(t *testing.T) {
 func TestGormDBGetEmptyRepo(t *testing.T) {
 	db, cleanup := setup(t)
 	defer cleanup()
-	if _, err := db.GetRepository(10); err != gorm.ErrRecordNotFound {
+	if _, err := db.GetRepositoryByRemoteID(10); err != gorm.ErrRecordNotFound {
 		t.Fatal(err)
 	}
 }
@@ -1198,7 +1198,7 @@ func TestGormDBGetSingleRepoWithUser(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := db.GetRepository(repo.RepositoryID); err != nil {
+	if _, err := db.GetRepositoryByRemoteID(repo.RepositoryID); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -1230,7 +1230,7 @@ func TestGormDBGetCourseRepoType(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	gotRepo, err := db.GetRepository(repo.RepositoryID)
+	gotRepo, err := db.GetRepositoryByRemoteID(repo.RepositoryID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/web/access_control.go
+++ b/web/access_control.go
@@ -110,7 +110,7 @@ func (s *AutograderService) getUserAndSCM(ctx context.Context, provider string) 
 // getUserAndSCM2 returns the current user and scm for the given course.
 // All errors are logged, but only a single error is returned to the client.
 // This is a helper method to facilitate consistent treatment of errors and logging.
-func (s *AutograderService) getUserAndSCM2(ctx context.Context, courseID uint64) (*pb.User, scm.SCM, error) {
+func (s *AutograderService) getUserAndSCMForCourse(ctx context.Context, courseID uint64) (*pb.User, scm.SCM, error) {
 	crs, err := s.getCourse(courseID)
 	if err != nil {
 		return nil, nil, status.Errorf(codes.NotFound, "failed to get course with ID %d: %w", courseID, err)

--- a/web/access_control.go
+++ b/web/access_control.go
@@ -107,7 +107,7 @@ func (s *AutograderService) getUserAndSCM(ctx context.Context, provider string) 
 	return usr, scm, nil
 }
 
-// getUserAndSCM2 returns the current user and scm for the given course.
+// getUserAndSCMForCourse returns the current user and scm for the given course.
 // All errors are logged, but only a single error is returned to the client.
 // This is a helper method to facilitate consistent treatment of errors and logging.
 func (s *AutograderService) getUserAndSCMForCourse(ctx context.Context, courseID uint64) (*pb.User, scm.SCM, error) {

--- a/web/autograder_service.go
+++ b/web/autograder_service.go
@@ -199,7 +199,7 @@ func (s *AutograderService) CreateEnrollment(ctx context.Context, in *pb.Enrollm
 // UpdateEnrollment updates the enrollment status of a student as specified in the request.
 // Access policy: Teacher of CourseID.
 func (s *AutograderService) UpdateEnrollment(ctx context.Context, in *pb.Enrollment) (*pb.Void, error) {
-	usr, scm, err := s.getUserAndSCM2(ctx, in.GetCourseID())
+	usr, scm, err := s.getUserAndSCMForCourse(ctx, in.GetCourseID())
 	if err != nil {
 		s.logger.Errorf("UpdateEnrollment failed: scm authentication error: %w", err)
 		return nil, ErrInvalidUserInfo
@@ -220,7 +220,7 @@ func (s *AutograderService) UpdateEnrollment(ctx context.Context, in *pb.Enrollm
 // UpdateEnrollments changes status of all pending enrollments for the given course to approved
 // Access policy: Teacher of CourseID
 func (s *AutograderService) UpdateEnrollments(ctx context.Context, in *pb.CourseRequest) (*pb.Void, error) {
-	usr, scm, err := s.getUserAndSCM2(ctx, in.GetCourseID())
+	usr, scm, err := s.getUserAndSCMForCourse(ctx, in.GetCourseID())
 	if err != nil {
 		s.logger.Errorf("UpdateEnrollments failed: authentication error: %w", err)
 		return nil, ErrInvalidUserInfo
@@ -362,7 +362,7 @@ func (s *AutograderService) CreateGroup(ctx context.Context, in *pb.Group) (*pb.
 // UpdateGroup updates group information.
 // Access policy: Teacher of CourseID.
 func (s *AutograderService) UpdateGroup(ctx context.Context, in *pb.Group) (*pb.Void, error) {
-	usr, scm, err := s.getUserAndSCM2(ctx, in.GetCourseID())
+	usr, scm, err := s.getUserAndSCMForCourse(ctx, in.GetCourseID())
 	if err != nil {
 		s.logger.Errorf("UpdateGroup failed: scm authentication error: %w", err)
 		return nil, ErrInvalidUserInfo
@@ -389,7 +389,7 @@ func (s *AutograderService) UpdateGroup(ctx context.Context, in *pb.Group) (*pb.
 func (s *AutograderService) DeleteGroup(ctx context.Context, in *pb.GroupRequest) (*pb.Void, error) {
 
 	// TODO(vera): will neen an scm passed to the web method in case we want to delete the group repo too (in.WithRepo == true)
-	usr, scm, err := s.getUserAndSCM2(ctx, in.GetCourseID())
+	usr, scm, err := s.getUserAndSCMForCourse(ctx, in.GetCourseID())
 	if err != nil {
 		s.logger.Errorf("DeleteGroup failed: authentication error: %w", err)
 		return nil, ErrInvalidUserInfo
@@ -513,7 +513,7 @@ func (s *AutograderService) GetAssignments(ctx context.Context, in *pb.CourseReq
 // Access policy: Teacher of CourseID.
 func (s *AutograderService) UpdateAssignments(ctx context.Context, in *pb.CourseRequest) (*pb.Void, error) {
 	courseID := in.GetCourseID()
-	usr, scm, err := s.getUserAndSCM2(ctx, courseID)
+	usr, scm, err := s.getUserAndSCMForCourse(ctx, courseID)
 	if err != nil {
 		s.logger.Errorf("UpdateAssignments failed: scm authentication error: %w", err)
 		return nil, err
@@ -586,7 +586,7 @@ func (s *AutograderService) GetRepositories(ctx context.Context, in *pb.URLReque
 // IsEmptyRepo ensures that group repository is empty and can be deleted
 // Access policy: Teacher of Course ID
 func (s *AutograderService) IsEmptyRepo(ctx context.Context, in *pb.RepositoryRequest) (*pb.Void, error) {
-	usr, scm, err := s.getUserAndSCM2(ctx, in.GetCourseID())
+	usr, scm, err := s.getUserAndSCMForCourse(ctx, in.GetCourseID())
 	if err != nil {
 		s.logger.Errorf("IsEmptyRepo failed: scm authentication error: %w", err)
 		return nil, err

--- a/web/courses.go
+++ b/web/courses.go
@@ -68,7 +68,7 @@ func (s *AutograderService) updateEnrollment(ctx context.Context, sc scm.SCM, re
 				fmt.Println("updateEnrollment: rejectUserFromCourse failed: ", err)
 			}
 
-			if err := s.db.DeleteRepository(repo.GetRepositoryID()); err != nil {
+			if err := s.db.DeleteRepositoryByRemoteID(repo.GetRepositoryID()); err != nil {
 				return err
 			}
 		}

--- a/web/groups.go
+++ b/web/groups.go
@@ -56,7 +56,7 @@ func (s *AutograderService) deleteGroup(ctx context.Context, sc scm.SCM, request
 
 	// when deleting an approved group, remove github repository and team as well
 	for _, repo := range repos {
-		if err = s.db.DeleteRepository(repo.GetID()); err != nil {
+		if err = s.db.DeleteRepositoryByRemoteID(repo.GetRepositoryID()); err != nil {
 			// even if database record not found, still attempt to remove related github repo and team
 			if err != gorm.ErrRecordNotFound {
 				return err

--- a/web/hooks.go
+++ b/web/hooks.go
@@ -43,7 +43,7 @@ func GithubHook(logger *zap.SugaredLogger, db database.Database, runner ci.Runne
 			p := payload.(github.PushPayload)
 			logger.Debug("Push event", zap.Any("payload", p))
 
-			repo, err := db.GetRepository(uint64(p.Repository.ID))
+			repo, err := db.GetRepositoryByRemoteID(uint64(p.Repository.ID))
 			if err != nil {
 				logger.Error("Failed to get repository from database", zap.Error(err))
 				return


### PR DESCRIPTION
- `GetUserAndSCM2` is now `GetUserAndSCMForCourse`
- gorm methods `GetRepository` and `DeleteRepository` are now `GetRepostoryByRemoteID` and `DeleteRepositoryByRemoteID` correspondingly, to reflect the expected ID type