### PR TITLE
updated deprecated fields in envoy config

### DIFF
--- a/envoy/envoy.yaml
+++ b/envoy/envoy.yaml
@@ -27,7 +27,8 @@ static_resources:
               - match: { prefix: "/" }
                 route: { cluster: ag_service, max_grpc_timeout: 0s }
               cors:
-                allow_origin: ["*"]
+                allow_origin_string_match:
+                - prefix: "*"
                 allow_methods: GET, PUT, DELETE, POST, OPTIONS
                 allow_headers: keep-alive,user-agent,cache-control,content-type,content-transfer-encoding,custom-header-1,x-accept-content-transfer-encoding,x-accept-response-streaming,x-user-agent,x-grpc-web,user
                 max_age: "1728000"


### PR DESCRIPTION
Envoy configuration field `allow_origin` has been deprecated. Because of that building a new envoy container based on the old `.yaml` file. became impossible. New field name is `allow_origin_string_match`.

Note: `regex` option for the `allow_origin_string_match` field is also deprecated, use `safe_regex` instead if needed.