### PR TITLE
Demote admins

### DIFF
--- a/cmd/agctl/main.go
+++ b/cmd/agctl/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
+	pb "github.com/autograde/aguis/ag"
 	"github.com/autograde/aguis/database"
 	_ "github.com/jinzhu/gorm/dialects/sqlite"
 	"github.com/urfave/cli"
@@ -54,7 +55,7 @@ func main() {
 						if !c.IsSet("id") {
 							return cli.NewExitError("not implemented", 9)
 						}
-						return db.SetAdmin(c.Uint64("id"))
+						return db.UpdateUser(&pb.User{ID: c.Uint64("id"), IsAdmin: true})
 					},
 				},
 			},

--- a/database/database.go
+++ b/database/database.go
@@ -26,10 +26,6 @@ type Database interface {
 	// UpdateUser updates the user's details, excluding remote identities.
 	UpdateUser(*pb.User) error
 
-	// SetAdmin makes an existing user an administrator. The admin role is allowed to
-	// create courses, so it makes sense that teachers are made admins.
-	SetAdmin(uint64) error
-
 	CreateCourse(uint64, *pb.Course) error
 	GetCourse(uint64, bool) (*pb.Course, error)
 	GetCourseByOrganizationID(did uint64) (*pb.Course, error)

--- a/database/gormdb.go
+++ b/database/gormdb.go
@@ -153,7 +153,13 @@ func (db *GormDB) GetUsers(uids ...uint64) ([]*pb.User, error) {
 
 // UpdateUser updates user information.
 func (db *GormDB) UpdateUser(user *pb.User) error {
+	// Updates will never update IsAdmin to false because of gorm restrictions
+	// we need to update IsAdmin field explicitly
+	if err := db.conn.Model(&pb.User{}).Where(&pb.User{ID: user.ID}).Update("is_admin", user.IsAdmin).Error; err != nil {
+		return err
+	}
 	return db.conn.Model(&pb.User{}).Updates(user).Error
+
 }
 
 // SetAdmin promotes user with given ID to admin.

--- a/database/gormdb_test.go
+++ b/database/gormdb_test.go
@@ -152,6 +152,7 @@ func TestGormDBUpdateUser(t *testing.T) {
 			StudentID: "22",
 			Email:     "scrooge@mc.duck",
 			AvatarURL: "https://github.com",
+			IsAdmin:   true, // have to set IsAdmin or will be switched back to false
 		}
 	)
 
@@ -175,6 +176,21 @@ func TestGormDBUpdateUser(t *testing.T) {
 	}
 
 	updatedUser, err := db.GetUser(user.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	updatedUser.Enrollments = nil
+	if !reflect.DeepEqual(updatedUser, wantUser) {
+		t.Errorf("have user %+v want %+v", updatedUser, wantUser)
+	}
+
+	// check that admin role can be revoked
+	updates.IsAdmin = false
+	wantUser.IsAdmin = false
+	if err := db.UpdateUser(updates); err != nil {
+		t.Fatal(err)
+	}
+	updatedUser, err = db.GetUser(user.ID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/database/gormdb_test.go
+++ b/database/gormdb_test.go
@@ -696,7 +696,7 @@ func TestGormDBSetAdminNoRecord(t *testing.T) {
 	db, cleanup := setup(t)
 	defer cleanup()
 
-	if err := db.SetAdmin(id); err != gorm.ErrRecordNotFound {
+	if err := db.UpdateUser(&pb.User{ID: id, IsAdmin: true}); err != gorm.ErrRecordNotFound {
 		t.Errorf("have error '%v' wanted '%v'", err, gorm.ErrRecordNotFound)
 	}
 }
@@ -734,7 +734,7 @@ func TestGormDBSetAdmin(t *testing.T) {
 		t.Error("user should not yet be an administrator")
 	}
 
-	if err := db.SetAdmin(user.ID); err != nil {
+	if err := db.UpdateUser(&pb.User{ID: user.ID, IsAdmin: true}); err != nil {
 		t.Error(err)
 	}
 

--- a/public/src/HttpHelper.ts
+++ b/public/src/HttpHelper.ts
@@ -52,7 +52,6 @@ export class HttpHelper {
                         console.log("Non JSON respons detected");
                     } else {
                         try {
-                            // console.log(request.responseText);
                             data = JSON.parse(request.responseText) as TReceive;
                         } catch (e) {
                             console.error("Could not parse response from server", e, request.responseText);

--- a/public/src/components/teacher/Results.tsx
+++ b/public/src/components/teacher/Results.tsx
@@ -53,11 +53,9 @@ export class Results extends React.Component<IResultsProp, IResultsState> {
                 onRebuildClick={this.props.onRebuildClick}
                 onApproveClick={ async (approve: boolean) => {
                     if (this.state.assignment && this.state.assignment.latest) {
-                        console.log("Approving: " + approve);
                         const ans = await this.props.onApproveClick(this.state.assignment.latest.id, approve);
                         if (ans) {
                             this.state.assignment.latest.approved = approve;
-                            console.log("Changed status: " + this.state.assignment.latest.approved);
                         }
                     }
                 }}

--- a/public/src/managers/GRPCManager.ts
+++ b/public/src/managers/GRPCManager.ts
@@ -65,18 +65,18 @@ export class GrpcManager {
     }
 
     public updateUser(user: User, isAdmin?: boolean): Promise<IGrpcResponse<User>> {
-        const requrest = new User();
-        requrest.setId(user.getId());
-        requrest.setAvatarurl(user.getAvatarurl());
-        requrest.setEmail(user.getEmail());
-        requrest.setName(user.getName());
-        requrest.setStudentid(user.getStudentid());
+        const request = new User();
+        request.setId(user.getId());
+        request.setAvatarurl(user.getAvatarurl());
+        request.setEmail(user.getEmail());
+        request.setName(user.getName());
+        request.setStudentid(user.getStudentid());
         if (isAdmin) {
-            requrest.setIsadmin(isAdmin);
+            request.setIsadmin(isAdmin);
         } else {
-            requrest.setIsadmin(user.getIsadmin());
+            request.setIsadmin(user.getIsadmin());
         }
-        return this.grpcSend(this.agService.updateUser, requrest);
+        return this.grpcSend(this.agService.updateUser, request);
     }
 
     public isAuthorizedTeacher(): Promise<IGrpcResponse<AuthorizationResponse>> {

--- a/public/src/managers/GRPCManager.ts
+++ b/public/src/managers/GRPCManager.ts
@@ -64,19 +64,8 @@ export class GrpcManager {
         return this.grpcSend<Users>(this.agService.getUsers, request);
     }
 
-    public updateUser(user: User, isAdmin?: boolean): Promise<IGrpcResponse<User>> {
-        const request = new User();
-        request.setId(user.getId());
-        request.setAvatarurl(user.getAvatarurl());
-        request.setEmail(user.getEmail());
-        request.setName(user.getName());
-        request.setStudentid(user.getStudentid());
-        if (isAdmin) {
-            request.setIsadmin(isAdmin);
-        } else {
-            request.setIsadmin(user.getIsadmin());
-        }
-        return this.grpcSend(this.agService.updateUser, request);
+    public updateUser(user: User): Promise<IGrpcResponse<User>> {
+        return this.grpcSend(this.agService.updateUser, user);
     }
 
     public isAuthorizedTeacher(): Promise<IGrpcResponse<AuthorizationResponse>> {

--- a/public/src/managers/ServerProvider.ts
+++ b/public/src/managers/ServerProvider.ts
@@ -299,8 +299,8 @@ export class ServerProvider implements IUserProvider, ICourseProvider {
         return null;
     }
 
-    public async changeAdminRole(user: User): Promise<boolean> {
-        const result = await this.grpcHelper.updateUser(user, true);
+    public async changeAdminRole(user: User, promote: boolean): Promise<boolean> {
+        const result = await this.grpcHelper.updateUser(user, promote);
         // we are not interested in user data returned in this case, only checking that there were no errors
         return result.status.getCode() === 0;
     }

--- a/public/src/managers/ServerProvider.ts
+++ b/public/src/managers/ServerProvider.ts
@@ -300,7 +300,8 @@ export class ServerProvider implements IUserProvider, ICourseProvider {
     }
 
     public async changeAdminRole(user: User, promote: boolean): Promise<boolean> {
-        const result = await this.grpcHelper.updateUser(user, promote);
+        user.setIsadmin(promote);
+        const result = await this.grpcHelper.updateUser(user);
         // we are not interested in user data returned in this case, only checking that there were no errors
         return result.status.getCode() === 0;
     }

--- a/public/src/managers/UserManager.ts
+++ b/public/src/managers/UserManager.ts
@@ -9,7 +9,7 @@ export interface IUserProvider {
     getUser(): Promise<User>;
     getAllUser(): Promise<User[]>;
     tryRemoteLogin(provider: string): Promise<User | null>;
-    changeAdminRole(user: User): Promise<boolean>;
+    changeAdminRole(user: User, promote: boolean): Promise<boolean>;
     getLoggedInUser(): Promise<User | null>;
     updateUser(user: User): Promise<boolean>;
     isAuthorizedTeacher(): Promise<boolean>;
@@ -104,8 +104,8 @@ export class UserManager {
         return this.userProvider.getAllUser();
     }
 
-    public async changeAdminRole(user: User): Promise<boolean> {
-        return this.userProvider.changeAdminRole(user);
+    public async changeAdminRole(user: User, promote: boolean): Promise<boolean> {
+        return this.userProvider.changeAdminRole(user, promote);
     }
 
     public updateUser(user: User): Promise<boolean> {

--- a/public/src/pages/AdminPage.tsx
+++ b/public/src/pages/AdminPage.tsx
@@ -73,7 +73,9 @@ export class AdminPage extends ViewPage {
     public async handleAdminRoleClick(user: IUserRelation): Promise<boolean> {
         if (this.userMan && this.navMan) {
             // promote non-admin user to admin, demote otherwise
+            console.log("Changing admin role: current role: " + user.user.getIsadmin());
             const res = await this.userMan.changeAdminRole(user.user, !user.user.getIsadmin());
+            console.log("Changing to IsAdmin = " + !user.user.getIsadmin());
             this.navMan.refresh();
             return res;
         }

--- a/public/src/pages/AdminPage.tsx
+++ b/public/src/pages/AdminPage.tsx
@@ -73,9 +73,7 @@ export class AdminPage extends ViewPage {
     public async handleAdminRoleClick(user: IUserRelation): Promise<boolean> {
         if (this.userMan && this.navMan) {
             // promote non-admin user to admin, demote otherwise
-            console.log("Changing admin role: current role: " + user.user.getIsadmin());
             const res = await this.userMan.changeAdminRole(user.user, !user.user.getIsadmin());
-            console.log("Changing to IsAdmin = " + !user.user.getIsadmin());
             this.navMan.refresh();
             return res;
         }

--- a/public/src/pages/AdminPage.tsx
+++ b/public/src/pages/AdminPage.tsx
@@ -72,7 +72,8 @@ export class AdminPage extends ViewPage {
 
     public async handleAdminRoleClick(user: IUserRelation): Promise<boolean> {
         if (this.userMan && this.navMan) {
-            const res = await this.userMan.changeAdminRole(user.user);
+            // promote non-admin user to admin, demote otherwise
+            const res = await this.userMan.changeAdminRole(user.user, !user.user.getIsadmin());
             this.navMan.refresh();
             return res;
         }

--- a/web/groups_test.go
+++ b/web/groups_test.go
@@ -529,7 +529,7 @@ func TestPatchGroupStatus(t *testing.T) {
 	if err := db.EnrollTeacher(teacher.ID, course.ID); err != nil {
 		t.Fatal(err)
 	}
-	if err := db.SetAdmin(teacher.ID); err != nil {
+	if err := db.UpdateUser(&pb.User{ID: teacher.ID, IsAdmin: true}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/web/submissions_test.go
+++ b/web/submissions_test.go
@@ -21,7 +21,7 @@ func TestSubmissionsAccess(t *testing.T) {
 	admin := createFakeUser(t, db, 1)
 
 	teacher := createFakeUser(t, db, 2)
-	db.SetAdmin(teacher.ID)
+	db.UpdateUser(&pb.User{ID: teacher.ID, IsAdmin: true})
 	var course pb.Course
 	course.Provider = "fake"
 	// only created 1 directory, if we had created two directories ID would be 2

--- a/web/submissions_test.go
+++ b/web/submissions_test.go
@@ -21,8 +21,7 @@ func TestSubmissionsAccess(t *testing.T) {
 	admin := createFakeUser(t, db, 1)
 
 	teacher := createFakeUser(t, db, 2)
-	teacher.IsAdmin = true
-	db.UpdateUser(teacher)
+	db.SetAdmin(teacher.ID)
 	var course pb.Course
 	course.Provider = "fake"
 	// only created 1 directory, if we had created two directories ID would be 2

--- a/web/users.go
+++ b/web/users.go
@@ -70,8 +70,9 @@ func (s *AutograderService) updateUser(isAdmin bool, request *pb.User) (*pb.User
 	if request.AvatarURL != "" {
 		updateUser.AvatarURL = request.AvatarURL
 	}
-	// current user must be admin to promote another user to admin
-	if isAdmin {
+	// current user must be admin to change admin status of another user
+	// admin status of super admin (user with ID 1) cannot be changed
+	if isAdmin && request.ID > 1 {
 		updateUser.IsAdmin = request.IsAdmin
 	}
 

--- a/web/users_test.go
+++ b/web/users_test.go
@@ -269,7 +269,7 @@ func TestUpdateUser(t *testing.T) {
 
 	// we want to update nonAdminUser to become admin
 	nonAdminUser.IsAdmin = true
-	respUser, err := ags.UpdateUser(ctx, nonAdminUser)
+	err := db.UpdateUser(nonAdminUser)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -284,8 +284,8 @@ func TestUpdateUser(t *testing.T) {
 	}
 
 	nameChangeRequest := &pb.User{
-		ID:        respUser.ID,
-		IsAdmin:   respUser.IsAdmin,
+		ID:        nonAdminUser.ID,
+		IsAdmin:   nonAdminUser.IsAdmin,
 		Name:      "Scrooge McDuck",
 		StudentID: "99",
 		Email:     "test@test.com",


### PR DESCRIPTION
Admins (unless super admin) can now be demoted. This will resolve the issue where students previously granted admin role as TAs could have admin access to other courses.