### PR TITLE
Approving a new group fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/labstack/echo v0.0.0-20170803061611-b42edd791fad
 	github.com/labstack/echo-contrib v0.0.0-20170707172923-c43bc4a1577d
-	github.com/labstack/gommon v0.2.9 // indirect
+	github.com/labstack/gommon v0.2.9
 	github.com/markbates/goth v0.0.0-20170721181425-c55b917ee947
 	github.com/mattn/go-sqlite3 v1.10.0
 	github.com/opencontainers/go-digest v1.0.0-rc0 // indirect

--- a/public/src/components/forms/GroupForm.tsx
+++ b/public/src/components/forms/GroupForm.tsx
@@ -251,15 +251,18 @@ export class GroupForm extends React.Component<IGroupProps, IGroupState> {
             errors.push("Group mush have members.");
         }
 
-        if (this.state.curUser
-            && (this.state.curUser.link.getStatus() === Enrollment.UserStatus.STUDENT
-                || this.state.curUser.link.getStatus() === Enrollment.UserStatus.TEACHER)
-            && !this.isCurrentStudentSelected(this.state.curUser)) {
-                if (this.state.curUser.link.getStatus() !== Enrollment.UserStatus.TEACHER) {
-                    errors.push("You must be a member of the group");
-                }
-        }
+        if (!this.userValidate(this.state.curUser)) {
+            errors.push("You must be a member of the group");
+        }        
         return errors;
+    }
+
+    private userValidate(curUser: IUserRelation | undefined): boolean {
+        if (curUser && curUser.link.getStatus() === Enrollment.UserStatus.TEACHER) {
+            return true
+        } else {
+            return curUser ? curUser.link.getStatus() === Enrollment.UserStatus.STUDENT && this.isCurrentStudentSelected(curUser) : false
+        }
     }
 
     private getFlashErrors(errors: string[]): JSX.Element {
@@ -278,13 +281,13 @@ export class GroupForm extends React.Component<IGroupProps, IGroupState> {
     }
 
     private isCurrentStudentSelected(student: IUserRelation): boolean {
-        let ans = false;
+        let foundSelected = false;
         this.state.selectedStudents.forEach((user) => {
             if (user.user.getId() === student.user.getId()) {
-                ans = true;
+                foundSelected = true;
             }
         })
-        return ans;
+        return foundSelected;
     }
 
     private getSelectedStudents(curUser: IUserRelation | undefined): IUserRelation[] {

--- a/public/src/components/forms/GroupForm.tsx
+++ b/public/src/components/forms/GroupForm.tsx
@@ -5,9 +5,7 @@ import { Search } from "../../components";
 import { CourseManager } from "../../managers/CourseManager";
 import { NavigationManager } from "../../managers/NavigationManager";
 import { UserManager } from "../../managers/UserManager";
-import {
-    IUserRelation,
-} from "../../models";
+import { IUserRelation } from "../../models";
 
 interface IGroupProps {
     className: string;
@@ -168,7 +166,6 @@ export class GroupForm extends React.Component<IGroupProps, IGroupState> {
                         : this.props.pagePath + "/courses/" + this.props.course.getId() + "/members";
 
                     this.props.navMan.navigateTo(redirectTo);
-
             }
         }
     }
@@ -210,7 +207,7 @@ export class GroupForm extends React.Component<IGroupProps, IGroupState> {
             const newStudentArr = this.state.students.slice();
             newStudentArr.splice(index, 1);
             this.setState({
-                students: newStudentArr, // this.state.students.filter((_, i) => i !== index),
+                students: newStudentArr,
                 selectedStudents: newSelectedArr,
             });
         }
@@ -253,14 +250,14 @@ export class GroupForm extends React.Component<IGroupProps, IGroupState> {
         if (this.state.selectedStudents.length === 0) {
             errors.push("Group mush have members.");
         }
+
         if (this.state.curUser
             && (this.state.curUser.link.getStatus() === Enrollment.UserStatus.STUDENT
                 || this.state.curUser.link.getStatus() === Enrollment.UserStatus.TEACHER)
             && !this.isCurrentStudentSelected(this.state.curUser)) {
-
-            if (this.state.curUser.link.getStatus() !== Enrollment.UserStatus.TEACHER) {
-                errors.push("You must be a member of the group");
-            }
+                if (this.state.curUser.link.getStatus() !== Enrollment.UserStatus.TEACHER) {
+                    errors.push("You must be a member of the group");
+                }
         }
         return errors;
     }
@@ -281,8 +278,13 @@ export class GroupForm extends React.Component<IGroupProps, IGroupState> {
     }
 
     private isCurrentStudentSelected(student: IUserRelation): boolean {
-        const index = this.state.selectedStudents.indexOf(student);
-        return index >= 0;
+        let ans = false;
+        this.state.selectedStudents.forEach((user) => {
+            if (user.user.getId() === student.user.getId()) {
+                ans = true;
+            }
+        })
+        return ans;
     }
 
     private getSelectedStudents(curUser: IUserRelation | undefined): IUserRelation[] {

--- a/scm/github.go
+++ b/scm/github.go
@@ -320,7 +320,7 @@ func (s *GithubSCM) ListHooks(ctx context.Context, repo *Repository, org string)
 		return nil, fmt.Errorf("ListHooks: found no hooks")
 	}
 	for _, hook := range gitHooks {
-		s.logger.Infof("Found hook with events: %s", hook.Events)
+		s.logger.Debugf("Found hook with events: %s", hook.Events)
 		hooks = append(hooks, &Hook{
 			ID:     uint64(hook.GetID()),
 			URL:    hook.GetURL(),
@@ -393,7 +393,7 @@ func (s *GithubSCM) CreateTeam(ctx context.Context, opt *TeamOptions) (*Team, er
 	// first check whether the team with this name already exists on this organization
 	team, _, err := s.client.Teams.GetTeamBySlug(ctx, opt.Organization.Path, slug.Make(opt.TeamName))
 	if err != nil {
-		s.logger.Infof("Team %s not found as expected: %s", opt.TeamName, err)
+		s.logger.Debugf("Team %s not found as expected: %s", opt.TeamName, err)
 	}
 
 	if team == nil {
@@ -409,7 +409,7 @@ func (s *GithubSCM) CreateTeam(ctx context.Context, opt *TeamOptions) (*Team, er
 				}
 			}
 			// continue if it is one of standard teacher/student teams. Such teams can be safely reused
-			s.logger.Infof("Team %s already exists on organization %s", opt.TeamName, opt.Organization.Path)
+			s.logger.Debugf("Team %s already exists on organization %s", opt.TeamName, opt.Organization.Path)
 		}
 	}
 

--- a/scm/github.go
+++ b/scm/github.go
@@ -135,13 +135,11 @@ func (s *GithubSCM) CreateRepository(ctx context.Context, opt *CreateRepositoryO
 	}
 
 	// first make sure that repo does not already exist for this user or group
-	s.logger.Debugf("GitHub, checking for repo with owner: %s and path: %s", opt.Owner, opt.Path)
-	repo, _, err := s.client.Repositories.Get(ctx, opt.Organization.Path, opt.Path)
+	repo, _, err := s.client.Repositories.Get(ctx, opt.Organization.Path, slug.Make(opt.Path))
 	if err != nil {
 		// in most cases the repo will not exist and "not found" error will be returned
 		s.logger.Debugf("CreateRepository got expected error when checking for %s repository: %s", opt.Path, err)
 	}
-	s.logger.Debugf("GitHub got group repo: %+v", repo)
 
 	if repo == nil {
 		repo, _, err = s.client.Repositories.Create(ctx, opt.Organization.Path, &github.Repository{
@@ -393,7 +391,6 @@ func (s *GithubSCM) CreateTeam(ctx context.Context, opt *TeamOptions) (*Team, er
 	}
 
 	// first check whether the team with this name already exists on this organization
-	s.logger.Debugf("GitHub: checking for existing team with name %s, slug %s, and org %s", opt.TeamName, slug.Make(opt.TeamName), opt.Organization.Path)
 	team, _, err := s.client.Teams.GetTeamBySlug(ctx, opt.Organization.Path, slug.Make(opt.TeamName))
 	if err != nil {
 		s.logger.Infof("Team %s not found as expected: %s", opt.TeamName, err)

--- a/scm/github.go
+++ b/scm/github.go
@@ -135,11 +135,13 @@ func (s *GithubSCM) CreateRepository(ctx context.Context, opt *CreateRepositoryO
 	}
 
 	// first make sure that repo does not already exist for this user or group
-	repo, _, err := s.client.Repositories.Get(ctx, opt.Owner, opt.Path)
+	s.logger.Debugf("GitHub, checking for repo with owner: %s and path: %s", opt.Owner, opt.Path)
+	repo, _, err := s.client.Repositories.Get(ctx, opt.Organization.Path, opt.Path)
 	if err != nil {
 		// in most cases the repo will not exist and "not found" error will be returned
 		s.logger.Debugf("CreateRepository got expected error when checking for %s repository: %s", opt.Path, err)
 	}
+	s.logger.Debugf("GitHub got group repo: %+v", repo)
 
 	if repo == nil {
 		repo, _, err = s.client.Repositories.Create(ctx, opt.Organization.Path, &github.Repository{
@@ -389,35 +391,45 @@ func (s *GithubSCM) CreateTeam(ctx context.Context, opt *TeamOptions) (*Team, er
 			Message: fmt.Sprintf("%+v", opt),
 		}
 	}
-	t, _, err := s.client.Teams.CreateTeam(ctx, opt.Organization.Path, github.NewTeam{
-		Name: opt.TeamName,
-	})
+
+	// first check whether the team with this name already exists on this organization
+	s.logger.Debugf("GitHub: checking for existing team with name %s, slug %s, and org %s", opt.TeamName, slug.Make(opt.TeamName), opt.Organization.Path)
+	team, _, err := s.client.Teams.GetTeamBySlug(ctx, opt.Organization.Path, slug.Make(opt.TeamName))
 	if err != nil {
-		if opt.TeamName != TeachersTeam && opt.TeamName != StudentsTeam {
-			return nil, ErrFailedSCM{
-				Method:   "CreateTeam",
-				Message:  fmt.Sprintf("failed to create GitHub team %s, make sure it does not already exist", opt.TeamName),
-				GitError: fmt.Errorf("failed to create GitHub team %s: %w", opt.TeamName, err),
+		s.logger.Infof("Team %s not found as expected: %s", opt.TeamName, err)
+	}
+
+	if team == nil {
+		team, _, err = s.client.Teams.CreateTeam(ctx, opt.Organization.Path, github.NewTeam{
+			Name: opt.TeamName,
+		})
+		if err != nil {
+			if opt.TeamName != TeachersTeam && opt.TeamName != StudentsTeam {
+				return nil, ErrFailedSCM{
+					Method:   "CreateTeam",
+					Message:  fmt.Sprintf("failed to create GitHub team %s, make sure it does not already exist", opt.TeamName),
+					GitError: fmt.Errorf("failed to create GitHub team %s: %w", opt.TeamName, err),
+				}
 			}
+			// continue if it is one of standard teacher/student teams. Such teams can be safely reused
+			s.logger.Infof("Team %s already exists on organization %s", opt.TeamName, opt.Organization.Path)
 		}
-		// continue if it is one of standard teacher/student teams. Such teams can be safely reused
-		s.logger.Infof("Team %s already exists on organization %s", opt.TeamName, opt.Organization.Path)
 	}
 
 	for _, user := range opt.Users {
-		_, _, err = s.client.Teams.AddTeamMembership(ctx, t.GetID(), user, nil)
+		_, _, err = s.client.Teams.AddTeamMembership(ctx, team.GetID(), user, nil)
 		if err != nil {
 			return nil, ErrFailedSCM{
 				Method:   "CreateTeam",
-				Message:  fmt.Sprintf("failed to add user '%s' to GitHub team '%s'", user, t.GetName()),
-				GitError: fmt.Errorf("failed to add '%s' to GitHub team '%s': %w", user, t.GetName(), err),
+				Message:  fmt.Sprintf("failed to add user '%s' to GitHub team '%s'", user, team.GetName()),
+				GitError: fmt.Errorf("failed to add '%s' to GitHub team '%s': %w", user, team.GetName(), err),
 			}
 		}
 	}
 	return &Team{
-		ID:   uint64(t.GetID()),
-		Name: t.GetName(),
-		URL:  t.GetURL(),
+		ID:   uint64(team.GetID()),
+		Name: team.GetName(),
+		URL:  team.GetURL(),
 	}, nil
 }
 

--- a/web/autograder_service.go
+++ b/web/autograder_service.go
@@ -357,7 +357,7 @@ func (s *AutograderService) GetGroupByUserAndCourse(ctx context.Context, in *pb.
 	return group, nil
 }
 
-// CreateGroup creates a new group.
+// CreateGroup creates a new group in the database.
 // Access policy: Any User enrolled in course and specified as member of the group or a course teacher.
 func (s *AutograderService) CreateGroup(ctx context.Context, in *pb.Group) (*pb.Group, error) {
 	usr, err := s.getCurrentUser(ctx)

--- a/web/autograder_service.go
+++ b/web/autograder_service.go
@@ -375,6 +375,9 @@ func (s *AutograderService) CreateGroup(ctx context.Context, in *pb.Group) (*pb.
 	}
 	group, err := s.createGroup(in)
 	if err != nil {
+		if err == ErrGroupNameDuplicate {
+			return nil, err
+		}
 		s.logger.Errorf("CreateGroup failed: %w", err)
 		return nil, status.Error(codes.InvalidArgument, "failed to create group")
 	}

--- a/web/groups.go
+++ b/web/groups.go
@@ -144,7 +144,7 @@ func (s *AutograderService) updateGroup(ctx context.Context, sc scm.SCM, request
 		return fmt.Errorf("updateGroup: organization not found: %w", err)
 	}
 
-	if len(repos) == 0 && group.GetTeamID() < 1 {
+	if len(repos) == 0 {
 		// found no repos for the group; create group repo and team
 		if request.GetName() != "" {
 			group.Name = request.Name
@@ -158,10 +158,11 @@ func (s *AutograderService) updateGroup(ctx context.Context, sc scm.SCM, request
 		groupRepo := &pb.Repository{
 			OrganizationID: course.OrganizationID,
 			RepositoryID:   repo.ID,
-			GroupID:        request.ID,
+			GroupID:        group.ID,
 			HTMLURL:        repo.WebURL,
 			RepoType:       pb.Repository_GROUP,
 		}
+		s.logger.Debugf("Creating group repo in the database with query: %+v", groupRepo)
 		if err := s.db.CreateRepository(groupRepo); err != nil {
 			return err
 		}

--- a/web/scm_helpers.go
+++ b/web/scm_helpers.go
@@ -194,6 +194,10 @@ func isEmpty(ctx context.Context, sc scm.SCM, repos []*pb.Repository) error {
 // creating a course, approving, changing status of, or deleting
 // a course enrollment or group
 func contextCanceled(ctx context.Context) bool {
+	// debugging context related errors
+	if ctx.Err() != nil {
+		fmt.Println("Context error: ", ctx.Err().Error())
+	}
 	return ctx.Err() == context.Canceled
 }
 


### PR DESCRIPTION
Sometimes a new group could not be approved because of canceled context on GitHub side. This way, repository or team for the group might have been created on GitHub, but nothing would be reflected in the database. As a result, approving such a group would become impossible because of GitHub and database mismatch.

This fix introduces following changes:

- two groups with names that would result in the same github repository name can no longer be created
- issue when some students could not create a new group with "not in group" error message is now fixed
- if a group repository or team already have been created on GitHub, this information will be updated in the database instead of failing the request
- a group that could not be approved due to GitHub related issues now can be approved later without any actions required from the user