### PR TITLE
Set assignment folder name as assignment name

### DIFF
--- a/assignments/assignments_parser.go
+++ b/assignments/assignments_parser.go
@@ -24,7 +24,6 @@ const (
 // public to allow parsing.
 type assignmentData struct {
 	AssignmentID uint   `yaml:"assignmentid"`
-	Name         string `yaml:"name"`
 	Language     string `yaml:"language"`
 	Deadline     string `yaml:"deadline"`
 	AutoApprove  bool   `yaml:"autoapprove"`
@@ -66,7 +65,7 @@ func parseAssignments(dir string, courseID uint64) ([]*pb.Assignment, error) {
 					newAssignment.ScoreLimit = defaultAutoApproveScoreLimit
 				}
 
-				// ID from the parsed yaml is used to set Order, not assignment ID,
+				// ID field from the parsed yaml is used to set Order, not assignment ID,
 				// or it will cause a database constraint violation (IDs must be unique)
 				assignment := &pb.Assignment{
 					CourseID:    courseID,

--- a/assignments/assignments_parser.go
+++ b/assignments/assignments_parser.go
@@ -33,12 +33,6 @@ type assignmentData struct {
 
 // ParseAssignments recursively walks the given directory and parses
 // any 'assignment.yml' files found and returns an array of assignments.
-// TODO(meling) Thinking: One complication with this approach is that we depend on the YAML's 'name' field
-//   being the same as the assignment name in the folder structure in the assignments repository.
-//   This is perhaps fine, but could be problematic if someone uses a name like "Lab assignment 1"
-//   and the folder is named only "lab1". We should make this more robust; can we add a field to the
-//   pb.Assignment type to hold the directory name, which should not be parsed from YAML, but computed
-//   in assignment_parser.go, based on parent directory of the YAML. Issue is that we may need to add it to the DB.
 func parseAssignments(dir string, courseID uint64) ([]*pb.Assignment, error) {
 	// check if directory exist
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
@@ -54,7 +48,6 @@ func parseAssignments(dir string, courseID uint64) ([]*pb.Assignment, error) {
 				if err != nil {
 					return fmt.Errorf("could not to read %q file: %w", filename, err)
 				}
-				labDirectoryName := filepath.Base(filepath.Dir(path))
 				var newAssignment assignmentData
 				err = yaml.Unmarshal(source, &newAssignment)
 				if err != nil {
@@ -71,7 +64,7 @@ func parseAssignments(dir string, courseID uint64) ([]*pb.Assignment, error) {
 					CourseID:    courseID,
 					Deadline:    newAssignment.Deadline,
 					Language:    strings.ToLower(newAssignment.Language),
-					Name:        labDirectoryName,
+					Name:        filepath.Base(filepath.Dir(path)),
 					Order:       uint32(newAssignment.AssignmentID),
 					AutoApprove: newAssignment.AutoApprove,
 					ScoreLimit:  uint32(newAssignment.ScoreLimit),

--- a/assignments/assignments_parser.go
+++ b/assignments/assignments_parser.go
@@ -55,6 +55,7 @@ func parseAssignments(dir string, courseID uint64) ([]*pb.Assignment, error) {
 				if err != nil {
 					return fmt.Errorf("could not to read %q file: %w", filename, err)
 				}
+				labDirectoryName := filepath.Base(filepath.Dir(path))
 				var newAssignment assignmentData
 				err = yaml.Unmarshal(source, &newAssignment)
 				if err != nil {
@@ -71,7 +72,7 @@ func parseAssignments(dir string, courseID uint64) ([]*pb.Assignment, error) {
 					CourseID:    courseID,
 					Deadline:    newAssignment.Deadline,
 					Language:    strings.ToLower(newAssignment.Language),
-					Name:        newAssignment.Name,
+					Name:        labDirectoryName,
 					Order:       uint32(newAssignment.AssignmentID),
 					AutoApprove: newAssignment.AutoApprove,
 					ScoreLimit:  uint32(newAssignment.ScoreLimit),

--- a/assignments/assignments_parser.go
+++ b/assignments/assignments_parser.go
@@ -60,6 +60,7 @@ func parseAssignments(dir string, courseID uint64) ([]*pb.Assignment, error) {
 
 				// ID field from the parsed yaml is used to set Order, not assignment ID,
 				// or it will cause a database constraint violation (IDs must be unique)
+				// The Name field below is the folder name of the assignment.
 				assignment := &pb.Assignment{
 					CourseID:    courseID,
 					Deadline:    newAssignment.Deadline,

--- a/assignments/assignments_parser_test.go
+++ b/assignments/assignments_parser_test.go
@@ -63,8 +63,10 @@ func TestParse(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// We expect assignment names to be set based on
+	// assignment folder names.
 	wantAssignment1 := &pb.Assignment{
-		Name:        "For loops",
+		Name:        "lab1",
 		Language:    "go",
 		Deadline:    "27-08-2017 12:00",
 		AutoApprove: false,
@@ -73,7 +75,7 @@ func TestParse(t *testing.T) {
 	}
 
 	wantAssignment2 := &pb.Assignment{
-		Name:        "Nested loops",
+		Name:        "lab2",
 		Language:    "java",
 		Deadline:    "27-08-2018 12:00",
 		AutoApprove: false,

--- a/web/access_control.go
+++ b/web/access_control.go
@@ -14,7 +14,7 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-// ErrInvalidUserInfo is returned to user if user information in context is invalid
+// ErrInvalidUserInfo is returned to user if user information in context is invalid.
 var ErrInvalidUserInfo = status.Errorf(codes.PermissionDenied, "authorization failed. please try to logout and sign in again")
 
 func (s *AutograderService) getCurrentUser(ctx context.Context) (*pb.User, error) {
@@ -78,8 +78,8 @@ func (s *AutograderService) isEnrolled(userID, courseID uint64) bool {
 	})
 }
 
-// isValidSubmission returns true if submitter has active course enrollment or
-// if submitting group belongs to the given course
+// isValidSubmission returns true if submitting student has active course enrollment or
+// if submitting group belongs to the given course.
 func (s *AutograderService) isValidSubmissionRequest(submission *pb.SubmissionRequest) bool {
 	if !submission.IsValid() {
 		return false
@@ -99,7 +99,7 @@ func (s *AutograderService) isValidSubmissionRequest(submission *pb.SubmissionRe
 }
 
 // isValidSubmission returns true if submission belongs to active lab of the given course
-// and submitted by valid student or group
+// and submitted by valid student or group.
 func (s *AutograderService) isValidSubmission(submissionID uint64) bool {
 	submission, err := s.db.GetSubmission(&pb.Submission{ID: submissionID})
 	if err != nil {
@@ -125,7 +125,7 @@ func (s *AutograderService) isTeacher(userID, courseID uint64) bool {
 	})
 }
 
-// isCourseCreator returns true if the given user is course creator for the given course
+// isCourseCreator returns true if the given user is course creator for the given course.
 func (s *AutograderService) isCourseCreator(courseID, userID uint64) bool {
 	course, _ := s.db.GetCourse(courseID, false)
 	return course.GetCourseCreatorID() == userID

--- a/web/assignments.go
+++ b/web/assignments.go
@@ -17,7 +17,7 @@ func (s *AutograderService) getAssignments(courseID uint64) (*pb.Assignments, er
 	return &pb.Assignments{Assignments: assignments}, nil
 }
 
-// updateAssignments updates the assignments for the given course
+// updateAssignments updates the assignments for the given course.
 func (s *AutograderService) updateAssignments(ctx context.Context, sc scm.SCM, courseID uint64) error {
 	course, err := s.db.GetCourse(courseID, false)
 	if err != nil {

--- a/web/courses.go
+++ b/web/courses.go
@@ -75,6 +75,8 @@ func (s *AutograderService) updateEnrollments(ctx context.Context, sc scm.SCM, c
 	return nil
 }
 
+// updateReposAndTeams changes access to the course repositories and team memberships of the given user
+// depending on the given enrollment status.
 func updateReposAndTeams(ctx context.Context, sc scm.SCM, course *pb.Course, login string, state pb.Enrollment_UserStatus) (*scm.Repository, error) {
 	org, err := sc.GetOrganization(ctx, &scm.GetOrgOptions{ID: course.OrganizationID})
 	if err != nil {
@@ -214,7 +216,7 @@ func (s *AutograderService) getEnrollmentsByCourse(request *pb.EnrollmentRequest
 	return &pb.Enrollments{Enrollments: enrollments}, nil
 }
 
-// getRepositoryURL returns the repository information
+// getRepositoryURL returns URL of a course repository of the given type.
 func (s *AutograderService) getRepositoryURL(currentUser *pb.User, courseID uint64, repoType pb.Repository_Type) (string, error) {
 	course, err := s.db.GetCourse(courseID, false)
 	if err != nil {
@@ -248,6 +250,8 @@ func (s *AutograderService) getRepositoryURL(currentUser *pb.User, courseID uint
 	return repos[0].HTMLURL, nil
 }
 
+// isEmptyRepo returns nil if all repositories for the given course and student or group are empty,
+// returns an error otherwise.
 func (s *AutograderService) isEmptyRepo(ctx context.Context, sc scm.SCM, request *pb.RepositoryRequest) error {
 	course, err := s.db.GetCourse(request.GetCourseID(), false)
 	if err != nil {
@@ -263,7 +267,7 @@ func (s *AutograderService) isEmptyRepo(ctx context.Context, sc scm.SCM, request
 	return isEmpty(ctx, sc, repos)
 }
 
-// rejectEnrollment rejects a student enrollment, if a student repo exists for the given course, removes it from the SCM and database
+// rejectEnrollment rejects a student enrollment, if a student repo exists for the given course, removes it from the SCM and database.
 func (s *AutograderService) rejectEnrollment(ctx context.Context, sc scm.SCM, enrolled *pb.Enrollment) error {
 	// course and user are both preloaded, no need to query the database
 	course, user := enrolled.GetCourse(), enrolled.GetUser()
@@ -289,7 +293,7 @@ func (s *AutograderService) rejectEnrollment(ctx context.Context, sc scm.SCM, en
 	return s.db.RejectEnrollment(user.ID, course.ID)
 }
 
-// enrollStudent enrolls the given user as a student into the given course
+// enrollStudent enrolls the given user as a student into the given course.
 func (s *AutograderService) enrollStudent(ctx context.Context, sc scm.SCM, enrolled *pb.Enrollment) error {
 	// course and user are both preloaded, no need to query the database
 	course, user := enrolled.GetCourse(), enrolled.GetUser()


### PR DESCRIPTION
To avoid possible mismatches between assignment name provided in the `assignment.yaml` file, and the actual assignment folder name (must be identical, but no way to enforce it), name the assignment by its folder. 
This will make the `Name` field in the yml files unnecessary.