### PR TITLE
fixed extractAssignment to also recognize commits with added/removed files

### DIFF
--- a/web/hooks/github.go
+++ b/web/hooks/github.go
@@ -118,7 +118,19 @@ func (wh githubWebHook) extractAssignments(payload *github.PushEvent, course *pb
 			// we assume the first path component holds the assignment name
 			name := strings.Split(modifiedFile, "/")[0]
 			modifiedAssignments[name] = true
-			wh.logger.Debugf("Commit %d (%s), file %d: %s", c, commit.GetID(), i, modifiedFile)
+			wh.logger.Debugf("Commit modified %d (%s), file %d: %s", c, commit.GetID(), i, modifiedFile)
+		}
+		for i, addedFile := range commit.Added {
+			// we assume the first path component holds the assignment name
+			name := strings.Split(addedFile, "/")[0]
+			modifiedAssignments[name] = true
+			wh.logger.Debugf("Commit added %d (%s), file %d: %s", c, commit.GetID(), i, addedFile)
+		}
+		for i, removedFile := range commit.Removed {
+			// we assume the first path component holds the assignment name
+			name := strings.Split(removedFile, "/")[0]
+			modifiedAssignments[name] = true
+			wh.logger.Debugf("Commit removed %d (%s), file %d: %s", c, commit.GetID(), i, removedFile)
 		}
 	}
 


### PR DESCRIPTION
The current `extractAssignment` function only examines the `commit.Modified` field. This doesn't capture commits that only rename/add/remove files. This commit fixes that by also examining the `commit.Added` and `commit.Removed` fields in order to extract the labX name.
