### PR TITLE
fix bug in processing of assignment strings from github

### DIFF
--- a/web/hooks/github_test.go
+++ b/web/hooks/github_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/autograde/aguis/ci"
 	"github.com/autograde/aguis/database"
 	"github.com/autograde/aguis/scm"
+	"github.com/google/go-cmp/cmp"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -96,4 +97,28 @@ func getLogger(verbose bool) *zap.SugaredLogger {
 		return logger.Sugar()
 	}
 	return zap.NewNop().Sugar()
+}
+
+func TestExtractChanges(t *testing.T) {
+	modifiedFiles := []string{
+		"go.mod",
+		"go.sum",
+		"exercise.go",
+		"README.md",
+		"lab2/fib.go",
+		"lab3/detector/fd.go",
+		"paxos/proposer.go",
+		"/hallo",
+		"",
+	}
+	want := map[string]bool{
+		"lab2":  true,
+		"lab3":  true,
+		"paxos": true,
+	}
+	got := make(map[string]bool)
+	extractChanges(modifiedFiles, got)
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("content mismatch (-want +got):\n%s", diff)
+	}
 }


### PR DESCRIPTION
This commit fixes a bug that was triggered when students push
changes that touch root-level files, that don't belong to any
assignments, e.g. go.mod or README.md and so forth.
The commit also includes a test case for the function that
process the data coming from github.

Note: it is sometimes easy to forget to return or continue when
processing an error. Should be on the lookout for such mistakes.